### PR TITLE
Using batched work items query API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 obj/
 .vs/
 *.csproj.user
+*.http

--- a/CloneDevOpsTemplate/IServices/IWorkItemService.cs
+++ b/CloneDevOpsTemplate/IServices/IWorkItemService.cs
@@ -4,6 +4,7 @@ namespace CloneDevOpsTemplate.IServices;
 
 public interface IWorkItemService
 {
-    Task<WorkItemQueryList> GetWorkItemsAsync(Guid projectId, string projectName);
+    Task<WorkItemsListQueryResult?> GetWorkItemsListAsync(Guid projectId, string projectName);
+    Task<WorkItems?> GetWorkItemsAsync(Guid projectId, int[] workItemIds);
     Task<WorkItem?> GetWorkItemAsync(Guid projectId, int workItemId);
 }

--- a/CloneDevOpsTemplate/Models/WorkItems.cs
+++ b/CloneDevOpsTemplate/Models/WorkItems.cs
@@ -4,13 +4,13 @@ namespace CloneDevOpsTemplate.Models;
 
 public class WorkItemsListQueryRequest
 {
-    public string Query { get; set; } = "";
+    public string Query { get; set; } = string.Empty;
 }
 
 public class WorkItemsListQueryResult
 {
-    public string QueryType { get; set; } = "";
-    public string QueryResultType { get; set; } = "";
+    public string QueryType { get; set; } = string.Empty;
+    public string QueryResultType { get; set; } = string.Empty;
     public DateTime AsOf { get; set; }
     public WorkItemsListQueryColumn[] Columns { get; set; } = [];
     public WorkItemsListQueryItem[] WorkItems { get; set; } = [];
@@ -18,15 +18,15 @@ public class WorkItemsListQueryResult
 
 public class WorkItemsListQueryColumn
 {
-    public string ReferenceName { get; set; } = "";
-    public string Name { get; set; } = "";
-    public string Url { get; set; } = "";
+    public string ReferenceName { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
 }
 
 public class WorkItemsListQueryItem
 {
-    public int Id { get; set; } = 0;
-    public string Url { get; set; } = "";
+    public int Id { get; set; }
+    public string Url { get; set; } = string.Empty;
 }
 
 public class WorkItem
@@ -35,23 +35,23 @@ public class WorkItem
     public int Rev { get; set; }
     public Fields Fields { get; set; } = new();
     public Relations[] Relations { get; set; } = [];
-    public string Url { get; set; } = "";
+    public string Url { get; set; } = string.Empty;
 }
 
 public class Fields
 {
     [JsonPropertyName("System.AreaPath")]
-    public string SystemAreaPath { get; set; } = "";
+    public string SystemAreaPath { get; set; } = string.Empty;
     [JsonPropertyName("System.TeamProject")]
-    public string SystemTeamProject { get; set; } = "";
+    public string SystemTeamProject { get; set; } = string.Empty;
     [JsonPropertyName("System.IterationPath")]
-    public string SystemIterationPath { get; set; } = "";
+    public string SystemIterationPath { get; set; } = string.Empty;
     [JsonPropertyName("System.WorkItemType")]
-    public string SystemWorkItemType { get; set; } = "";
+    public string SystemWorkItemType { get; set; } = string.Empty;
     [JsonPropertyName("System.State")]
-    public string SystemState { get; set; } = "";
+    public string SystemState { get; set; } = string.Empty;
     [JsonPropertyName("System.Reason")]
-    public string SystemReason { get; set; } = "";
+    public string SystemReason { get; set; } = string.Empty;
     [JsonPropertyName("System.CreatedDate")]
     public DateTime SystemCreatedDate { get; set; }
     [JsonPropertyName("System.CreatedBy")]
@@ -61,64 +61,42 @@ public class Fields
     [JsonPropertyName("System.ChangedBy")]
     public TeamMember SystemChangedBy { get; set; } = new();
     [JsonPropertyName("System.Title")]
-    public string SystemTitle { get; set; } = "";
+    public string SystemTitle { get; set; } = string.Empty;
     [JsonPropertyName("Microsoft.VSTS.Scheduling.Effort")]
     public float MicrosoftVSTSSchedulingEffort { get; set; }
     [JsonPropertyName("System.Description")]
-    public string SystemDescription { get; set; } = "";
+    public string SystemDescription { get; set; } = string.Empty;
     [JsonPropertyName("System.AssignedTo")]
     public TeamMember SystemAssignedTo { get; set; } = new();
     [JsonPropertyName("System.BoardLane")]
-    public string SystemBoardLane { get; set; } = "";
+    public string SystemBoardLane { get; set; } = string.Empty;
     [JsonPropertyName("Microsoft.VSTS.Scheduling.RemainingWork")]
     public float MicrosoftVSTSSchedulingRemainingWork { get; set; }
     [JsonPropertyName("Microsoft.VSTS.Common.Priority")]
     public float MicrosoftVSTSCommonPriority { get; set; }
     [JsonPropertyName("System.Tags")]
-    public string SystemTags { get; set; } = "";
+    public string SystemTags { get; set; } = string.Empty;
     [JsonPropertyName("Microsoft.VSTS.TCM.Steps")]
-    public string MicrosoftVSTSTCMSteps { get; set; } = "";
+    public string MicrosoftVSTSTCMSteps { get; set; } = string.Empty;
     [JsonPropertyName("Microsoft.VSTS.TCM.Parameters")]
-    public string MicrosoftVSTSTCMParameters { get; set; } = "";
+    public string MicrosoftVSTSTCMParameters { get; set; } = string.Empty;
     [JsonPropertyName("Microsoft.VSTS.TCM.LocalDataSource")]
-    public string MicrosoftVSTSTCMLocalDataSource { get; set; } = "";
+    public string MicrosoftVSTSTCMLocalDataSource { get; set; } = string.Empty;
     [JsonPropertyName("Microsoft.VSTS.TCM.AutomationStatus")]
-    public string MicrosoftVSTSTCMAutomationStatus { get; set; } = "";
+    public string MicrosoftVSTSTCMAutomationStatus { get; set; } = string.Empty;
     [JsonPropertyName("Microsoft.VSTS.Common.AcceptanceCriteria")]
-    public string MicrosoftVSTSCommonAcceptanceCriteria { get; set; } = "";
+    public string MicrosoftVSTSCommonAcceptanceCriteria { get; set; } = string.Empty;
 }
 
 public class Relations
 {
-    public string Rel { get; set; } = "";
-    public string Url { get; set; } = "";
-    public Dictionary<string, string> Attributes { get; set; } = new();
-}
-
-[JsonConverter(typeof(JsonStringEnumConverter<WorkItemExpand>))]
-public enum WorkItemExpand
-{
-    None,
-    Relations,
-    Fields,
-    Links,
-    All
-}
-
-[JsonConverter(typeof(JsonStringEnumConverter<WorkItemErrorPolicy>))]
-public enum WorkItemErrorPolicy
-{
-    Fail,
-    Omit
+    public string Rel { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+    public Dictionary<string, string> Attributes { get; set; } = [];
 }
 
 public class WorkItemsQueryRequest
 {
-    [JsonPropertyName("$expand")]
-    public WorkItemExpand Expand { get; set; } = WorkItemExpand.None;
-    public WorkItemErrorPolicy ErrorPolicy { get; set; } = WorkItemErrorPolicy.Fail;
-    public DateTime AsOf { get; set; }
-    public string[] Fields { get; set; } = [];
     public int[] Ids { get; set; } = [];
 }
 

--- a/CloneDevOpsTemplate/Models/WorkItems.cs
+++ b/CloneDevOpsTemplate/Models/WorkItems.cs
@@ -2,28 +2,28 @@ using System.Text.Json.Serialization;
 
 namespace CloneDevOpsTemplate.Models;
 
-public class WorkItemQueryRequest
+public class WorkItemsListQueryRequest
 {
     public string Query { get; set; } = "";
 }
 
-public class WorkItemQueryList
+public class WorkItemsListQueryResult
 {
     public string QueryType { get; set; } = "";
     public string QueryResultType { get; set; } = "";
     public DateTime AsOf { get; set; }
-    public WorkItemQueryColumn[] Columns { get; set; } = [];
-    public WorkItemQueryItem[] WorkItems { get; set; } = [];
+    public WorkItemsListQueryColumn[] Columns { get; set; } = [];
+    public WorkItemsListQueryItem[] WorkItems { get; set; } = [];
 }
 
-public class WorkItemQueryColumn
+public class WorkItemsListQueryColumn
 {
     public string ReferenceName { get; set; } = "";
     public string Name { get; set; } = "";
     public string Url { get; set; } = "";
 }
 
-public class WorkItemQueryItem
+public class WorkItemsListQueryItem
 {
     public int Id { get; set; } = 0;
     public string Url { get; set; } = "";
@@ -93,4 +93,37 @@ public class Relations
     public string Rel { get; set; } = "";
     public string Url { get; set; } = "";
     public Dictionary<string, string> Attributes { get; set; } = new();
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter<WorkItemExpand>))]
+public enum WorkItemExpand
+{
+    None,
+    Relations,
+    Fields,
+    Links,
+    All
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter<WorkItemErrorPolicy>))]
+public enum WorkItemErrorPolicy
+{
+    Fail,
+    Omit
+}
+
+public class WorkItemsQueryRequest
+{
+    [JsonPropertyName("$expand")]
+    public WorkItemExpand Expand { get; set; } = WorkItemExpand.None;
+    public WorkItemErrorPolicy ErrorPolicy { get; set; } = WorkItemErrorPolicy.Fail;
+    public DateTime AsOf { get; set; }
+    public string[] Fields { get; set; } = [];
+    public int[] Ids { get; set; } = [];
+}
+
+public class WorkItems
+{
+    public int Count { get; set; }
+    public WorkItem[] Value { get; set; } = [];
 }

--- a/CloneDevOpsTemplate/Services/WorkItemService.cs
+++ b/CloneDevOpsTemplate/Services/WorkItemService.cs
@@ -26,17 +26,6 @@ public class WorkItemService(IHttpClientFactory httpClientFactory) : IWorkItemSe
     {
         WorkItemsQueryRequest wiQueryRequest = new()
         {
-            AsOf = DateTime.UtcNow,
-            Fields =                    // This must be extended if additional fields are needed to display
-            [
-                "System.Id", 
-                "System.Title", 
-                "System.AssignedTo", 
-                "System.IterationPath", 
-                "Microsoft.VSTS.Scheduling.Effort", 
-                "Microsoft.VSTS.Common.Priority", 
-                "System.WorkItemType"
-            ],
             Ids = workItemIds,
         };
         

--- a/CloneDevOpsTemplate/Views/WorkItems/WorkItems.cshtml
+++ b/CloneDevOpsTemplate/Views/WorkItems/WorkItems.cshtml
@@ -12,7 +12,9 @@
     <table class="table table-striped">
         <thead>
             <tr class="table-primary">
-                <th colspan="4"><h2>@workItem.Fields.SystemTitle</h2></th>
+                <th colspan="4">
+                    <h2>@workItem.Fields.SystemTitle</h2>
+                </th>
             </tr>
         </thead>
         <tbody>
@@ -21,7 +23,7 @@
                 <td>@workItem.Fields.SystemAssignedTo.DisplayName</td>
                 <td>@workItem.Fields.SystemAssignedTo.UniqueName</td>
                 <td>
-                    <img style="width: auto; height: auto;" src="@workItem.Fields.SystemAssignedTo.ImageUrl" />
+                    <img src="@workItem.Fields.SystemAssignedTo.ImageUrl" alt="@workItem.Fields.SystemAssignedTo.DisplayName" />
                 </td>
             </tr>
             <tr>

--- a/CloneDevOpsTemplateTest/Controllers/WorkItemsControllerTest.cs
+++ b/CloneDevOpsTemplateTest/Controllers/WorkItemsControllerTest.cs
@@ -39,29 +39,29 @@ public class WorkItemsControllerTest
         var projectId = Guid.NewGuid();
         var projectName = "TestProject";
 
-        var workItemQueryList = new WorkItemQueryList
+        var workItemQueryList = new WorkItemsListQueryResult
         {
-            WorkItems = new List<WorkItemQueryItem>
+            WorkItems = new List<WorkItemsListQueryItem>
             {
-                new WorkItemQueryItem { Id = 1 },
-                new WorkItemQueryItem { Id = 2 }
+                new WorkItemsListQueryItem { Id = 1 },
+                new WorkItemsListQueryItem { Id = 2 }
             }.ToArray()
         };
 
         var workItem1 = new WorkItem { Id = 1, Fields = new Fields { SystemTitle = "WorkItem1" } };
         var workItem2 = new WorkItem { Id = 2, Fields = new Fields { SystemTitle = "WorkItem2" } };
+        var workItems = new WorkItems
+        {
+            Value = [workItem1, workItem2]
+        };
 
         _mockWorkItemService
-            .Setup(s => s.GetWorkItemsAsync(projectId, projectName))
+            .Setup(s => s.GetWorkItemsListAsync(projectId, projectName))
             .ReturnsAsync(workItemQueryList);
 
         _mockWorkItemService
-            .Setup(s => s.GetWorkItemAsync(projectId, 1))
-            .ReturnsAsync(workItem1);
-
-        _mockWorkItemService
-            .Setup(s => s.GetWorkItemAsync(projectId, 2))
-            .ReturnsAsync(workItem2);
+            .Setup(s => s.GetWorkItemsAsync(projectId, new[] { 1, 2 }))
+            .ReturnsAsync(workItems);
 
         // Act
         var result = await _controller.WorkItems(projectId, projectName);
@@ -82,8 +82,8 @@ public class WorkItemsControllerTest
         var projectName = "TestProject";
 
         _mockWorkItemService
-            .Setup(s => s.GetWorkItemsAsync(projectId, projectName))
-            .ReturnsAsync(new WorkItemQueryList { WorkItems = [] });
+            .Setup(s => s.GetWorkItemsListAsync(projectId, projectName))
+            .ReturnsAsync(new WorkItemsListQueryResult { WorkItems = [] });
 
         // Act
         var result = await _controller.WorkItems(projectId, projectName);


### PR DESCRIPTION
- added /workitemsbatch API call in WorkItemService
- WorkItemsController splits the queried id list into 200 entry chunks
- only the batched REST endpoint is called from now (due to performance)
- added, fixed unit tests