### PR TITLE
Using Html.Raw() method call for WorkItem description

### DIFF
--- a/CloneDevOpsTemplate/Views/WorkItems/WorkItem.cshtml
+++ b/CloneDevOpsTemplate/Views/WorkItems/WorkItem.cshtml
@@ -17,7 +17,7 @@
     <tbody>
         <tr>
             <td>Description</td>
-            <td colspan="3">@fields.SystemDescription</td>
+            <td colspan="3">@Html.Raw(fields.SystemDescription)</td>
         </tr>
         <tr>
             @{ var assignedTo = fields.SystemAssignedTo; }


### PR DESCRIPTION
This ensures that HTML content is formatted correctly